### PR TITLE
ツイートスケジュールを一時間おきに変更

### DIFF
--- a/main.py
+++ b/main.py
@@ -142,7 +142,7 @@ def main():
         scheduler_list[scheduler_name].add_job(
             post_tweet,
             "interval",
-            minutes=30,
+            hours=1,
             args=[asin_list, shortened_url_list, scheduler_name],
         )
 


### PR DESCRIPTION
# 目的

ツイートの頻度を30分→1時間に変更する

# やったこと

- `apscheduler.add_job()`のintervalの指定を`minutes=30`→`hours=1`へ変更