### PR TITLE
【不具合対応】2日目以降のスケジューラの待機時間の計算エラー

### DIFF
--- a/main.py
+++ b/main.py
@@ -147,7 +147,9 @@ def main():
         )
 
     for key, scheduler in scheduler_list.items():
-        exec_datetime = datetime.datetime.strptime(key, "%Y-%m-%d")
+        exec_datetime = datetime.datetime.strptime(key, "%Y-%m-%d").astimezone(
+            ZoneInfo("Asia/Tokyo")
+        )
         now_datetime = datetime.datetime.now(ZoneInfo("Asia/Tokyo"))
         if exec_datetime.date() == now_datetime.date():
             post_tweet(asin_list, shortened_url_list, scheduler_name)


### PR DESCRIPTION
# 目的

2日目以降のスケジューラの待機時間の計算処理で発生していたエラーの解消

# やったこと

- 現在日時（`now_datetime`）のみタイムゾーンが指定してあったため、ツイート日時（`exec_datetime`）の方にもタイムゾーンを指定した