### PR TITLE
【不具合対応】ツイート間隔を正しい時間に修正

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -32,7 +32,7 @@ def create_scheduler(asin_list, short_url_list, target_date, job_function):
     scheduler_list[target_date].add_job(
         job_function,
         "interval",
-        seconds=3,
+        hours=1,
         args=[asin_list, short_url_list, target_date],
     )
 


### PR DESCRIPTION
# 目的

リファクタリングの際に3秒おきに変更したものを戻し忘れていたため、元の1時間おきに修正

# やったこと

- `apscheduler.add_job()`の`interval`の指定を`hours=1`に変更