### PR TITLE
引数の入力ファイルを削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-input.json
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,6 @@
             "program": "main.py",
             "console": "integratedTerminal",
             "justMyCode": true,
-            "args": ["input.json"]
         }
     ]
 }


### PR DESCRIPTION
# 目的

商品選定を自動化したため、今まで引数の入力ファイルとしていた`input.json`を削除する

# やったこと

- `input.json`を削除
- `.gitignore`からinput.jsonの記述を削除