### PR TITLE
【不具合対応】ブランド名取得エラーを解消

### DIFF
--- a/product.py
+++ b/product.py
@@ -113,6 +113,8 @@ def get_product_info(amazon_api):
             product
             for product in product_list
             if product.offers.listings[0].price.savings is not None
+            and product.offers.listings[0].price.savings.percentage is not None
+            and product.item_info.by_line_info.brand.display_value is not None
         ]
         discounted_product_count = len(discounted_product_list)
         if discounted_product_count > 0:


### PR DESCRIPTION
# 目的

ブランド名の取得処理で発生していた下記エラーの解消

```bash
AttributeError: 'NoneType' object has no attribute 'display_value'display_value
```

# やったこと

- セール商品の選別処理でブランド名の存在チェックをするように修正（割引率についてもチェックを追加） 