### PR TITLE
ツイート間隔を30分に変更

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -5,7 +5,7 @@ scheduler = BlockingScheduler(timezone="Asia/Tokyo")
 
 def add_job(job_function, amazon_api, twitter_auth):
     scheduler.add_job(
-        job_function, "interval", minutes=15, args=[amazon_api, twitter_auth]
+        job_function, "interval", minutes=30, args=[amazon_api, twitter_auth]
     )
 
 


### PR DESCRIPTION
## 目的

15分ごとにツイートしてしまうとTwitterAPIの月あたりの投稿上限(1500)に引っかかってしまうため、30分に設定する

## やったこと

- `apscheduler.add_job()`でスケジューラにジョブを追加する際に設定する間隔(`interval`)の値を15→30分に変更