### PR TITLE
テストコードを作成

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,8 @@
-from dotenv import load_dotenv
 import sys
-
 sys.path.append("src")
 
-from api import auth_amazon_api, auth_twitter_api
+from dotenv import load_dotenv
+
 from scheduler import add_job, start_scheduler
 from tweet import post_tweet
 
@@ -11,12 +10,9 @@ from tweet import post_tweet
 def main():
     load_dotenv()
 
-    AMAZON_API = auth_amazon_api()
-    TWITTER_AUTH = auth_twitter_api()
+    add_job(post_tweet)
 
-    add_job(post_tweet, AMAZON_API, TWITTER_AUTH)
-
-    start_scheduler(post_tweet, AMAZON_API, TWITTER_AUTH)
+    start_scheduler(post_tweet)
 
 
 if __name__ == "__main__":

--- a/src/product.py
+++ b/src/product.py
@@ -3,7 +3,8 @@ import re
 
 from pyshorteners import Shortener
 
-shortener = Shortener()
+from api import auth_amazon_api
+
 
 BROWSE_NODE_LIST = [
     "15325701",  # キャンプ用グリル・焚火台
@@ -74,7 +75,10 @@ def omit_product_title(product_title):
     return product_title
 
 
-def get_product_info(amazon_api):
+def get_product_info():
+    shortener = Shortener()
+    amazon_api = auth_amazon_api()
+
     is_found = False
     while not is_found:
         target_browse_node_index = random.randint(0, len(BROWSE_NODE_LIST) - 1)
@@ -99,12 +103,14 @@ def get_product_info(amazon_api):
             ]
             is_found = not is_found
 
-    product_title = discounted_product.item_info.title.display_value
-    discount_rate = discounted_product.offers.listings[0].price.savings.percentage
-    short_url = shortener.tinyurl.short(discounted_product.detail_page_url)
-    brand = discounted_product.item_info.by_line_info.brand.display_value
+            product_title = discounted_product.item_info.title.display_value
+            discount_rate = discounted_product.offers.listings[
+                0
+            ].price.savings.percentage
+            short_url = shortener.tinyurl.short(discounted_product.detail_page_url)
+            brand = discounted_product.item_info.by_line_info.brand.display_value
 
     product_title = hashtagging_brand_names_in_product_titie(product_title, brand)
     product_title = omit_product_title(product_title)
 
-    return discount_rate, product_title, short_url
+    return [discount_rate, product_title, short_url]

--- a/src/product.py
+++ b/src/product.py
@@ -45,30 +45,6 @@ BROWSE_NODE_LIST = [
 ]
 
 
-def extract_asin_from_url(url):
-    # 通常の商品ページのURLからASINを抽出
-    match = re.search(r"/dp/(\w{10})", url)
-    if match:
-        return match.group(1)
-
-    # 別の形式のURLからASINを抽出
-    match = re.search(r"/gp/product/(\w{10})", url)
-    if match:
-        return match.group(1)
-
-    return None
-
-
-def get_asin_and_short_url_list(url_list):
-    asin_list = []
-    short_url_list = []
-    for url in url_list:
-        asin_list.append(extract_asin_from_url(url))
-        short_url_list.append(shortener.tinyurl.short(url))
-
-    return asin_list, short_url_list
-
-
 def hashtagging_brand_names_in_product_titie(product_title, brand):
     brand_notation_list = re.split("[()]", brand)
     for brand_notation in brand_notation_list:

--- a/src/product.py
+++ b/src/product.py
@@ -101,7 +101,6 @@ def get_product_info():
             discounted_product = discounted_product_list[
                 random.randint(0, discounted_product_count - 1)
             ]
-            is_found = not is_found
 
             product_title = discounted_product.item_info.title.display_value
             discount_rate = discounted_product.offers.listings[
@@ -109,6 +108,8 @@ def get_product_info():
             ].price.savings.percentage
             short_url = shortener.tinyurl.short(discounted_product.detail_page_url)
             brand = discounted_product.item_info.by_line_info.brand.display_value
+
+            is_found = not is_found
 
     product_title = hashtagging_brand_names_in_product_titie(product_title, brand)
     product_title = omit_product_title(product_title)

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -3,12 +3,10 @@ from apscheduler.schedulers.blocking import BlockingScheduler
 scheduler = BlockingScheduler(timezone="Asia/Tokyo")
 
 
-def add_job(job_function, amazon_api, twitter_auth):
-    scheduler.add_job(
-        job_function, "interval", minutes=30, args=[amazon_api, twitter_auth]
-    )
+def add_job(job_function):
+    scheduler.add_job(job_function, "interval", minutes=30)
 
 
-def start_scheduler(job_function, amazon_api, twitter_auth):
-    job_function(amazon_api, twitter_auth)
+def start_scheduler(job_function):
+    job_function()
     scheduler.start()

--- a/src/tests/test_product.py
+++ b/src/tests/test_product.py
@@ -1,0 +1,229 @@
+import unittest
+from unittest.mock import patch
+
+from product import (
+    hashtagging_brand_names_in_product_titie,
+    omit_product_title,
+    get_product_info,
+)
+
+
+class TestProduct(unittest.TestCase):
+    def test_hashtagging_brand_names_in_product_titie(self):
+        test_cases = [
+            {
+                # ブランド名の中に半角スペースが存在しない
+                "product_title": "ソト (SOTO) マイクロトーチ",
+                "brand": "ソト(SOTO)",
+                "expected": "#ソト  (#SOTO ) マイクロトーチ",
+            },
+            {
+                # ブランド名の中に半角スペースが存在する
+                "product_title": "スノーピーク(snow peak) HOME&CAMPバーナー",
+                "brand": "Snow Peak(スノーピーク)",
+                "expected": "#スノーピーク (#SnowPeak ) HOME&CAMPバーナー",
+            },
+            {
+                # ブランド名が英語のみ
+                "product_title": "Naturehike 寝袋",
+                "brand": "Naturehike",
+                "expected": "#Naturehike  寝袋",
+            },
+            {
+                # 「ブランド名に半角スペースが存在する」かつ「商品タイトルには半角スペースが存在しない」
+                "product_title": "PrimeCamp エアーポンプ",
+                "brand": "Prime Camp",
+                "expected": "#PrimeCamp  エアーポンプ",
+            },
+        ]
+
+        for test_case in test_cases:
+            result = hashtagging_brand_names_in_product_titie(
+                test_case["product_title"], test_case["brand"]
+            )
+            self.assertEqual(result, test_case["expected"])
+
+    def test_omit_product_title(self):
+        test_cases = [
+            {
+                # 商品タイトルが61文字以上
+                "product_title": "[#ソト  (#SOTO )] 日本製 キャンドル 風 ガスランタン 専用スタビライザー 転倒防止 折りたたみ式 コンパク",
+                "expected": "[#ソト  (#SOTO )] 日本製 キャンドル 風 ガスランタン 専用スタビライザー 転倒防止 折りたたみ式 コンパ…",
+            },
+            {
+                # 商品タイトルが60文字
+                "product_title": "[#ソト  (#SOTO )] 日本製 キャンドル 風 ガスランタン 専用スタビライザー 転倒防止 折りたたみ式 コンパ",
+                "expected": "[#ソト  (#SOTO )] 日本製 キャンドル 風 ガスランタン 専用スタビライザー 転倒防止 折りたたみ式 コンパ…",
+            },
+            {
+                # 商品タイトルが59文字以下
+                "product_title": "[#ソト  (#SOTO )] 日本製 キャンドル 風 ガスランタン 専用スタビライザー 転倒防止 折りたたみ式 コン",
+                "expected": "[#ソト  (#SOTO )] 日本製 キャンドル 風 ガスランタン 専用スタビライザー 転倒防止 折りたたみ式 コン",
+            },
+        ]
+
+        for test_case in test_cases:
+            result = omit_product_title(test_case["product_title"])
+            self.assertEqual(result, test_case["expected"])
+
+    @patch("product.Shortener")
+    @patch("product.auth_amazon_api")
+    def test_get_product_info(self, mock_auth_amazon_api, mock_shortener):
+        test_cases = [
+            {
+                # 割引に関する情報がNoneの場合
+                "data": [
+                    {
+                        "offers": {"listings": [{"price": {"savings": None}}]},
+                        "item_info": {
+                            "title": {"display_value": "テスト商品1"},
+                            "by_line_info": {"brand": {"display_value": "テストブランド1"}},
+                        },
+                        "detail_page_url": "http://test1.com",
+                    },
+                    {
+                        "offers": {
+                            "listings": [{"price": {"savings": {"percentage": 20}}}]
+                        },
+                        "item_info": {
+                            "title": {"display_value": "テスト商品2"},
+                            "by_line_info": {"brand": {"display_value": "テストブランド2"}},
+                        },
+                        "detail_page_url": "http://test2.com",
+                    },
+                    {
+                        "offers": {
+                            "listings": [{"price": {"savings": {"percentage": 30}}}]
+                        },
+                        "item_info": {
+                            "title": {"display_value": "テスト商品3"},
+                            "by_line_info": {"brand": {"display_value": "テストブランド3"}},
+                        },
+                        "detail_page_url": "http://test3.com",
+                    },
+                ],
+                "expected": [20, "テスト商品2", "http://tinyurl.com/test"],
+            },
+            {
+                # ブランド名がNoneの場合
+                "data": [
+                    {
+                        "offers": {
+                            "listings": [{"price": {"savings": {"percentage": 10}}}]
+                        },
+                        "item_info": {
+                            "title": {"display_value": "テスト商品1"},
+                            "by_line_info": {"brand": {"display_value": None}},
+                        },
+                        "detail_page_url": "http://amazon.com",
+                    },
+                    {
+                        "offers": {
+                            "listings": [{"price": {"savings": {"percentage": 20}}}]
+                        },
+                        "item_info": {
+                            "title": {"display_value": "テスト商品2"},
+                            "by_line_info": {"brand": {"display_value": "テストブランド2"}},
+                        },
+                        "detail_page_url": "http://test2.com",
+                    },
+                    {
+                        "offers": {
+                            "listings": [{"price": {"savings": {"percentage": 30}}}]
+                        },
+                        "item_info": {
+                            "title": {"display_value": "テスト商品3"},
+                            "by_line_info": {"brand": {"display_value": "テストブランド3"}},
+                        },
+                        "detail_page_url": "http://test3.com",
+                    },
+                ],
+                "expected": [20, "テスト商品2", "http://tinyurl.com/test"],
+            },
+            {
+                # 商品タイトルがNoneの場合
+                "data": [
+                    {
+                        "offers": {
+                            "listings": [{"price": {"savings": {"percentage": 10}}}]
+                        },
+                        "item_info": {
+                            "title": {"display_value": None},
+                            "by_line_info": {"brand": {"display_value": "テストブランド1"}},
+                        },
+                        "detail_page_url": "http://amazon.com",
+                    },
+                    {
+                        "offers": {
+                            "listings": [{"price": {"savings": {"percentage": 20}}}]
+                        },
+                        "item_info": {
+                            "title": {"display_value": "テスト商品2"},
+                            "by_line_info": {"brand": {"display_value": "テストブランド2"}},
+                        },
+                        "detail_page_url": "http://test2.com",
+                    },
+                    {
+                        "offers": {
+                            "listings": [{"price": {"savings": {"percentage": 30}}}]
+                        },
+                        "item_info": {
+                            "title": {"display_value": "テスト商品3"},
+                            "by_line_info": {"brand": {"display_value": "テストブランド3"}},
+                        },
+                        "detail_page_url": "http://test3.com",
+                    },
+                ],
+                "expected": [20, "テスト商品2", "http://tinyurl.com/test"],
+            },
+            {
+                # 商品詳細ページURLがNoneの場合
+                "data": [
+                    {
+                        "offers": {
+                            "listings": [{"price": {"savings": {"percentage": 10}}}]
+                        },
+                        "item_info": {
+                            "title": {"display_value": "テスト商品1"},
+                            "by_line_info": {"brand": {"display_value": "テストブランド1"}},
+                        },
+                        "detail_page_url": None,
+                    },
+                    {
+                        "offers": {
+                            "listings": [{"price": {"savings": {"percentage": 20}}}]
+                        },
+                        "item_info": {
+                            "title": {"display_value": "テスト商品2"},
+                            "by_line_info": {"brand": {"display_value": "テストブランド2"}},
+                        },
+                        "detail_page_url": "http://test2.com",
+                    },
+                    {
+                        "offers": {
+                            "listings": [{"price": {"savings": {"percentage": 30}}}]
+                        },
+                        "item_info": {
+                            "title": {"display_value": "テスト商品3"},
+                            "by_line_info": {"brand": {"display_value": "テストブランド3"}},
+                        },
+                        "detail_page_url": "http://test3.com",
+                    },
+                ],
+                "expected": [20, "テスト商品2", "http://tinyurl.com/test"],
+            },
+        ]
+
+        for test_case in test_cases:
+            mock_shortener.return_value.tinyurl.short.return_value = (
+                "http://tinyurl.com/test"
+            )
+            mock_auth_amazon_api.return_value.search_items.return_value = test_case
+
+            result = get_product_info()
+
+            self.assertEqual(result, test_case["expected"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/test_tweet.py
+++ b/src/tests/test_tweet.py
@@ -1,0 +1,37 @@
+import unittest
+
+from tweet import create_content
+
+
+class TestTweet(unittest.TestCase):
+    def test_create_content(self):
+        test_case = {
+            "discount_rate": 10,
+            "product_title": "テスト商品1",
+            "short_url": "http://tinyurl.com/test",
+            "expected": {
+                "text": f"""
+【10%オフ！】
+
+テスト商品1
+
+詳細は🔽からチェック✔
+http://tinyurl.com/test
+
+#キャンプ
+#アウトドア
+#キャンプ好きと繋がりたい
+        """
+            },
+        }
+
+        result = create_content(
+            test_case["discount_rate"],
+            test_case["product_title"],
+            test_case["short_url"],
+        )
+        self.assertEqual(result, test_case["expected"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tweet.py
+++ b/src/tweet.py
@@ -1,6 +1,7 @@
+import logging
 import requests
-from api import POST_TWEET_ENDPOINT
 
+from api import auth_twitter_api, POST_TWEET_ENDPOINT
 from product import get_product_info
 
 
@@ -21,8 +22,10 @@ def create_content(discount_rate, product_title, short_url):
     }
 
 
-def post_tweet(amazon_api, twitter_auth):
-    discount_rate, product_title, short_url = get_product_info(amazon_api)
+def post_tweet():
+    TWITTER_AUTH = auth_twitter_api()
+
+    discount_rate, product_title, short_url = get_product_info()
 
     content = create_content(
         discount_rate,
@@ -30,5 +33,5 @@ def post_tweet(amazon_api, twitter_auth):
         short_url,
     )
 
-    response = requests.post(POST_TWEET_ENDPOINT, auth=twitter_auth, json=content)
+    response = requests.post(POST_TWEET_ENDPOINT, auth=TWITTER_AUTH, json=content)
     print(response.json())


### PR DESCRIPTION
# 目的

保守性の向上のためテストコードを作成する


# やったこと

## メイン

- 商品情報取得に関する処理（`product.py`）の各関数のテストコードを作成
- 上記テストコードで発覚したバグ修正
- ツイートに関する処理（`tweet.py`）のツイート本文作成処理（`create_content()`）のテストコードを作成（（`post_tweet`）はここでテストすべき処理がなかったため省略）

## ついで
- テストコード置く場所を検討した際、ロジックを置くディレクトリを用意したほうが良いと判断し新たに（`src`）ディレクトリを作成し、その中にテストコード用ディレクトリ（`tests`）を作成
- 上記対応でコンテナ内の作業ディレクトリ（`src`）と名前が被ったためサービス名・コンテナ内名を変更
- 使用されていない関数があったため削除
