### PR TITLE
ポストに割引金額の情報を追加

### DIFF
--- a/src/product.py
+++ b/src/product.py
@@ -94,6 +94,7 @@ def get_product_info():
             for product in product_list
             if product.offers.listings[0].price.savings is not None
             and product.offers.listings[0].price.savings.percentage is not None
+            and product.offers.listings[0].price.savings.amount is not None
             and product.item_info.by_line_info.brand.display_value is not None
         ]
         discounted_product_count = len(discounted_product_list)
@@ -106,6 +107,9 @@ def get_product_info():
             discount_rate = discounted_product.offers.listings[
                 0
             ].price.savings.percentage
+            discount_amount = round(
+                discounted_product.offers.listings[0].price.savings.amount
+            )
             short_url = shortener.tinyurl.short(discounted_product.detail_page_url)
             brand = discounted_product.item_info.by_line_info.brand.display_value
 
@@ -114,4 +118,4 @@ def get_product_info():
     product_title = hashtagging_brand_names_in_product_titie(product_title, brand)
     product_title = omit_product_title(product_title)
 
-    return [discount_rate, product_title, short_url]
+    return [discount_rate, discount_amount, product_title, short_url]

--- a/src/tweet.py
+++ b/src/tweet.py
@@ -5,10 +5,10 @@ from api import auth_twitter_api, POST_TWEET_ENDPOINT
 from product import get_product_info
 
 
-def create_content(discount_rate, product_title, short_url):
+def create_content(discount_rate, discount_amount, product_title, short_url):
     return {
         "text": f"""
-【{discount_rate}%オフ！】
+【{discount_rate}%({discount_amount}円)オフ！】
 
 {product_title}
 
@@ -25,10 +25,11 @@ def create_content(discount_rate, product_title, short_url):
 def post_tweet():
     TWITTER_AUTH = auth_twitter_api()
 
-    discount_rate, product_title, short_url = get_product_info()
+    discount_rate, discount_amount, product_title, short_url = get_product_info()
 
     content = create_content(
         discount_rate,
+        discount_amount,
         product_title,
         short_url,
     )


### PR DESCRIPTION
# 目的

より直感的に割引の程度がわかるように実際の値下げ額をポストに記載する

# やったこと

* 商品情報取得時に値下げ額も取得する
* 値下げ額を四捨五入して整数値にする
* ポスト本文の割引率の直後に値下げ額を記載

