### PR TITLE
ポストに1枚目の商品画像を添付

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -4,6 +4,7 @@ from requests_oauthlib import OAuth1
 
 
 POST_TWEET_ENDPOINT = "https://api.twitter.com/2/tweets"
+MEDIA_UPLOAD_ENDPOINT = "https://upload.twitter.com/1.1/media/upload.json"
 
 
 def auth_amazon_api():

--- a/src/product.py
+++ b/src/product.py
@@ -1,5 +1,6 @@
 import random
 import re
+import requests
 
 from pyshorteners import Shortener
 
@@ -110,6 +111,7 @@ def get_product_info():
             discount_amount = round(
                 discounted_product.offers.listings[0].price.savings.amount
             )
+            image = requests.get(discounted_product.images.primary.large.url).content
             short_url = shortener.tinyurl.short(discounted_product.detail_page_url)
             brand = discounted_product.item_info.by_line_info.brand.display_value
 
@@ -118,4 +120,4 @@ def get_product_info():
     product_title = hashtagging_brand_names_in_product_titie(product_title, brand)
     product_title = omit_product_title(product_title)
 
-    return [discount_rate, discount_amount, product_title, short_url]
+    return [discount_rate, discount_amount, product_title, short_url, image]

--- a/src/tweet.py
+++ b/src/tweet.py
@@ -1,13 +1,11 @@
-import logging
 import requests
 
-from api import auth_twitter_api, POST_TWEET_ENDPOINT
+from api import auth_twitter_api, POST_TWEET_ENDPOINT, MEDIA_UPLOAD_ENDPOINT
 from product import get_product_info
 
 
 def create_content(discount_rate, discount_amount, product_title, short_url):
-    return {
-        "text": f"""
+    return f"""
 【{discount_rate}%({discount_amount}円)オフ！】
 
 {product_title}
@@ -19,13 +17,12 @@ def create_content(discount_rate, discount_amount, product_title, short_url):
 #アウトドア
 #キャンプ好きと繋がりたい
         """
-    }
 
 
 def post_tweet():
     TWITTER_AUTH = auth_twitter_api()
 
-    discount_rate, discount_amount, product_title, short_url = get_product_info()
+    discount_rate, discount_amount, product_title, short_url, image = get_product_info()
 
     content = create_content(
         discount_rate,
@@ -34,5 +31,10 @@ def post_tweet():
         short_url,
     )
 
-    response = requests.post(POST_TWEET_ENDPOINT, auth=TWITTER_AUTH, json=content)
+    media_id = requests.post(
+        MEDIA_UPLOAD_ENDPOINT, auth=TWITTER_AUTH, files={"media": image}
+    ).json()["media_id_string"]
+    payload = {"text": content, "media": {"media_ids": [media_id]}}
+
+    response = requests.post(POST_TWEET_ENDPOINT, auth=TWITTER_AUTH, json=payload)
     print(response.json())


### PR DESCRIPTION
## 目的

リンクプレビューが表示されないことが多くぱっと見でどんな商品なのか分かりにくかったため、　　
あらかじめ商品画像を添付する。

## やったこと

* 取得した商品情報から1枚目の商品画像のURL(`product.images.primary.large.url`)を取得
  * 画像サイズはlarge,medium,smallがあるが、画像が小さいほど実際の表示がボケる事が多いため最大サイズのlargeを選択
* 取得したURLから`requests`で画像をダウンロードしメモリ上に保存
* 画像をTwitterAPIv1.1の「POST media/upload」でアップロードし、添付する画像のID(`media_id`)を取得
* 画像のIDを使用し、ポストに画像を添付