### PR TITLE
ポスト本文に絵文字を追加

### DIFF
--- a/src/tweet.py
+++ b/src/tweet.py
@@ -6,11 +6,11 @@ from product import get_product_info
 
 def create_content(discount_rate, discount_amount, product_title, short_url):
     return f"""
-【{discount_rate}%({discount_amount}円)オフ！】
+🏷️ {discount_rate}%🈹 {discount_amount}円オフ！ 🏷️
 
 {product_title}
 
-詳細は🔽からチェック✔
+詳細は下記リンクからチェック☑️
 {short_url}
 
 #キャンプ


### PR DESCRIPTION
## 目的

ポストが目に止まりやすいようにする。

## やったこと

* 1行目の割引率、割引額をセールの絵文字「🏷️」で囲む
* 「オフ！」の部分を割引の絵文字「🈹」に置換
* チェックマークが適度に目立つように「☑️」に変更