### PR TITLE
商品タイトルの省略処理の可変対応

### DIFF
--- a/src/product.py
+++ b/src/product.py
@@ -69,11 +69,8 @@ def hashtagging_brand_names_in_product_titie(product_title, brand):
     return product_title
 
 
-def omit_product_title(product_title):
-    if len(product_title) >= 60:
-        product_title = product_title[:60] + "…"
-
-    return product_title
+def shorten_product_title(product_title, excess_length):
+    return product_title[:-excess_length] + "…"
 
 
 def get_product_info():
@@ -118,6 +115,5 @@ def get_product_info():
             is_found = not is_found
 
     product_title = hashtagging_brand_names_in_product_titie(product_title, brand)
-    product_title = omit_product_title(product_title)
 
     return [discount_rate, discount_amount, product_title, short_url, image]

--- a/src/tweet.py
+++ b/src/tweet.py
@@ -1,10 +1,22 @@
 import requests
 
 from api import auth_twitter_api, POST_TWEET_ENDPOINT, MEDIA_UPLOAD_ENDPOINT
-from product import get_product_info
+from product import get_product_info, shorten_product_title
+
+POST_MAX_LENGTH = 140
+POST_TEMPLATE_TOTAL_LENGTH = 63  # 固定の文字列 + 三点リーダ「…」の合計文字数
 
 
 def create_content(discount_rate, discount_amount, product_title, short_url):
+    product_info_total_length = len(
+        str(discount_rate) + str(discount_amount) + product_title + short_url
+    )
+    post_total_length = POST_TEMPLATE_TOTAL_LENGTH + product_info_total_length
+
+    if post_total_length > POST_MAX_LENGTH:
+        excess_length = post_total_length - POST_MAX_LENGTH
+        product_title = shorten_product_title(product_title, excess_length)
+
     return f"""
 🏷️ {discount_rate}%🈹 {discount_amount}円オフ！ 🏷️
 


### PR DESCRIPTION
## 目的
商品タイトルの文字数制限が固定の文字数（60文字）になっていたため、商品タイトル以外の合計文字数やポストの文字数上限等によらず正しく省略されるようにする

## やったこと

* ポストの文字数上限(`POST_MAX_LENGTH`)とポストテンプレートに最低限含まれる文字数(`POST_TEMPLATE_TOTAL_LENGTH`)から省略すべき文字数を計算
* `omit_product_title()`の関数名が曖昧だったため省略する意味を強めて`shorten_product_title()`に変更