### PR TITLE
商品タイトル省略の可変対応&開発環境の見直し

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,12 +5,12 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Python: 現在のファイル",
+            "name": "Python: main.py",
             "type": "python",
             "request": "launch",
-            "program": "main.py",
-            "console": "integratedTerminal",
-            "justMyCode": true,
+            "program": "${workspaceRoot}/main.py",
+            "console": "internalConsole",
+            "justMyCode": true
         }
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
 FROM python:3.11.5
 
-RUN pip install amazon-paapi5 apscheduler requests_oauthlib pyshorteners python-dotenv
+WORKDIR /workspace/
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   app:
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.8'
 services:
   app:
     restart: always

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+amazon-paapi5==1.1.2
+APScheduler==3.10.4
+requests_oauthlib==1.3.1
+pyshorteners==1.0.1
+python-dotenv==1.0.0

--- a/src/product.py
+++ b/src/product.py
@@ -69,11 +69,8 @@ def hashtagging_brand_names_in_product_titie(product_title, brand):
     return product_title
 
 
-def omit_product_title(product_title):
-    if len(product_title) >= 60:
-        product_title = product_title[:60] + "…"
-
-    return product_title
+def shorten_product_title(product_title, excess_length):
+    return product_title[:-excess_length] + "…"
 
 
 def get_product_info():
@@ -118,6 +115,5 @@ def get_product_info():
             is_found = not is_found
 
     product_title = hashtagging_brand_names_in_product_titie(product_title, brand)
-    product_title = omit_product_title(product_title)
 
     return [discount_rate, discount_amount, product_title, short_url, image]

--- a/src/tweet.py
+++ b/src/tweet.py
@@ -1,10 +1,22 @@
 import requests
 
 from api import auth_twitter_api, POST_TWEET_ENDPOINT, MEDIA_UPLOAD_ENDPOINT
-from product import get_product_info
+from product import get_product_info, shorten_product_title
+
+POST_MAX_LENGTH = 140
+POST_TEMPLATE_TOTAL_LENGTH = 63  # 固定の文字列 + 三点リーダ「…」の合計文字数
 
 
 def create_content(discount_rate, discount_amount, product_title, short_url):
+    product_info_total_length = len(
+        str(discount_rate) + str(discount_amount) + product_title + short_url
+    )
+    post_total_length = POST_TEMPLATE_TOTAL_LENGTH + product_info_total_length
+
+    if post_total_length > POST_MAX_LENGTH:
+        excess_length = post_total_length - POST_MAX_LENGTH
+        product_title = shorten_product_title(product_title, excess_length)
+
     return f"""
 🏷️ {discount_rate}%🈹 {discount_amount}円オフ！ 🏷️
 


### PR DESCRIPTION
## 目的

* 商品タイトルの省略をポストの文字数上限から逆算するようにする
* 開発環境の見直し

## やったこと

* 商品によらず一定の文字数を(`POST_TEMPLATE_TOTAL_LENGTH `)、ポストの文字数上限(`POST_MAX_LENGTH `)を定数として定義
* `POST_TEMPLATE_TOTAL_LENGTH `と商品タイトルの文字数の合計がポストの文字数上限以下の場合は何もせず、超える場合は超える文字数分省略する処理を実装
* 商品タイトルを省略する関数はポストの文字数上限を超えるときのみ呼び出すように変更
* `Dockerfile`で`WORKDIR`を設定し、pipパッケージのインストールは`requirements.txt`を元に行うように変更
* `launch.json`の設定の名前、実行プログラムのパス、コンソールの設定を変更