### PR TITLE
ポスト内容のインデントの調整方法を変更

### DIFF
--- a/src/domain/post.py
+++ b/src/domain/post.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import re
+from textwrap import dedent
 
 
 @dataclass(init=False, frozen=False)
@@ -50,18 +51,20 @@ class Post:
         return target_content[:-shorten_length] + "…"
 
     def create_content(self, dynamic_content_list):
-        return f"""
-🏷️ {dynamic_content_list[0]}%🈹 {dynamic_content_list[1]}円オフ！ 🏷️
+        return dedent(
+            f"""
+                🏷️ {dynamic_content_list[0]}%🈹 {dynamic_content_list[1]}円オフ！ 🏷️
 
-{dynamic_content_list[2]}
+                {dynamic_content_list[2]}
 
-詳細は下記リンクからチェック☑️
-{dynamic_content_list[3]}
+                詳細は下記リンクからチェック☑️
+                {dynamic_content_list[3]}
 
-#キャンプ
-#アウトドア
-#キャンプ好きと繋がりたい
+                #キャンプ
+                #アウトドア
+                #キャンプ好きと繋がりたい
             """
+        )
 
     def create_post(self, content, media_id):
         return {"text": content, "media": {"media_ids": [media_id]}}

--- a/src/tests/domain/test_post.py
+++ b/src/tests/domain/test_post.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 import unittest
 
 from domain.post import Post
@@ -105,7 +106,20 @@ class TestPost(unittest.TestCase):
                 "テスト商品1",
                 "http://tinyurl.com/test",
             ],
-            "expected": "\n🏷️ 10%🈹 1000円オフ！ 🏷️\n\nテスト商品1\n\n詳細は下記リンクからチェック☑️\nhttp://tinyurl.com/test\n\n#キャンプ\n#アウトドア\n#キャンプ好きと繋がりたい\n            ",
+            "expected": dedent(
+                f"""
+                    🏷️ 10%🈹 1000円オフ！ 🏷️
+
+                    テスト商品1
+
+                    詳細は下記リンクからチェック☑️
+                    http://tinyurl.com/test
+
+                    #キャンプ
+                    #アウトドア
+                    #キャンプ好きと繋がりたい
+                """
+            ),
         }
 
         result = self.post.create_content(


### PR DESCRIPTION
## 目的

ポスト内容のインデント管理をやりやすくする

## やったこと

* Python組み込みライブラリ`textwrap.dedent`でPython由来のインデントを除外し、インデントを他のコードと同レベルに修正