### PR TITLE
ハッシュタグが2重になってしまう不具合を修正

### DIFF
--- a/src/application/usecase/post_camp_gear_sale_use_case.py
+++ b/src/application/usecase/post_camp_gear_sale_use_case.py
@@ -26,6 +26,8 @@ class PostCampGearSaleUseCase:
         for bn in brand_notation_list:
             product.title = post.add_hashtags(product.title, bn)
 
+        product.title = product.title.replace("##", "#")
+
         excess_length = post.calculate_excess_length(
             [
                 product.title,


### PR DESCRIPTION
# 目的

空白を含む英語のブランド名を含む場合、ハッシュタグが2重についてしまう場合がある不具合を修正する

# やったこと

- ハッシュタグ化処理（`add_hashtags()`）の後「##」を「#」に置き換える