### PR TITLE
PA-APIの利用方法をpipから公式SDKに変更&リクエスト間隔を1秒に設定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,11 @@ WORKDIR /workspace/
 
 RUN pip install --no-cache-dir -r requirements.txt
 
+RUN curl -O https://webservices.amazon.com/paapi5/documentation/assets/archives/paapi5-python-sdk-example.zip \
+    && unzip paapi5-python-sdk-example.zip \
+    && cd paapi5-python-sdk-example \
+    && python setup.py install \
+    && cd .. \
+    && rm -rf paapi5-python-sdk-example.zip paapi5-python-sdk-example
+
 ENV PYTHONPATH=/workspace/src:${PYTHONPATH}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-python-amazon-paapi==5.0.1
 requests_oauthlib==1.3.1
 pyshorteners==1.0.1
 python-dotenv==1.0.0

--- a/src/infrastructure/service/product_service.py
+++ b/src/infrastructure/service/product_service.py
@@ -1,8 +1,6 @@
 import os
 import random
-
-from amazon_paapi import AmazonApi
-from amazon_paapi.errors.exceptions import TooManyRequests, RequestError
+import time
 
 from paapi5_python_sdk.api.default_api import DefaultApi
 from paapi5_python_sdk.models.partner_type import PartnerType
@@ -125,6 +123,8 @@ class ProductService:
                     exc_info=True,
                 )
                 continue
+            finally:
+                time.sleep(1)
 
         return Product(
             title=sale_product.item_info.title.display_value,

--- a/src/infrastructure/service/product_service.py
+++ b/src/infrastructure/service/product_service.py
@@ -3,6 +3,12 @@ import random
 
 from amazon_paapi import AmazonApi
 from amazon_paapi.errors.exceptions import TooManyRequests, RequestError
+
+from paapi5_python_sdk.api.default_api import DefaultApi
+from paapi5_python_sdk.models.partner_type import PartnerType
+from paapi5_python_sdk.rest import ApiException
+from paapi5_python_sdk.models.search_items_request import SearchItemsRequest
+from paapi5_python_sdk.models.search_items_resource import SearchItemsResource
 import requests
 
 from domain.product import Product
@@ -51,12 +57,12 @@ class ProductService:
     ]
 
     def auth_amazon_api(self):
-        ACCESS_KEY = os.environ["ACCESS_KEY"]
-        SECRET_KEY = os.environ["SECRET_KEY"]
-        ASSOCIATE_ID = os.environ["ASSOCIATE_ID"]
-        COUNTRY = "JP"
-
-        return AmazonApi(ACCESS_KEY, SECRET_KEY, ASSOCIATE_ID, COUNTRY)
+        return DefaultApi(
+            access_key=os.environ["ACCESS_KEY"],
+            secret_key=os.environ["SECRET_KEY"],
+            host=os.environ["HOST"],
+            region=os.environ["REGION"],
+        )
 
     def fetch_sale_product(self):
         amazon_api = self.auth_amazon_api()
@@ -68,11 +74,21 @@ class ProductService:
 
             try:
                 sale_product_list = amazon_api.search_items(
-                    browse_node_id=self.BROWSE_NODE_LIST[target_browse_node_index],
-                    item_page=target_page,
-                    item_count=10,
-                    min_saving_percent=1,
-                ).items
+                    SearchItemsRequest(
+                        partner_tag=os.environ["ASSOCIATE_ID"],
+                        partner_type=PartnerType.ASSOCIATES,
+                        browse_node_id=self.BROWSE_NODE_LIST[target_browse_node_index],
+                        item_page=target_page,
+                        item_count=10,
+                        min_saving_percent=1,
+                        resources=[
+                            SearchItemsResource.ITEMINFO_TITLE,
+                            SearchItemsResource.ITEMINFO_BYLINEINFO,
+                            SearchItemsResource.OFFERS_LISTINGS_PRICE,
+                            SearchItemsResource.IMAGES_PRIMARY_LARGE,
+                        ],
+                    )
+                ).search_result.items
 
                 sale_product_list = [
                     sale_product
@@ -92,14 +108,9 @@ class ProductService:
                     ]
                     is_found = not is_found
                     logger.info("選択した商品情報 : %s", sale_product)
-            except TooManyRequests as e:
+            except ApiException as e:
                 logger.error(
-                    f"PA-APIのレート上限に達しました。: {e}",
-                    exc_info=True,
-                )
-            except RequestError as e:
-                logger.error(
-                    f"PA-APIへのリクエストが失敗しました。: {e}",
+                    f"PA-APIへのリクエスト時にエラーが発生しました。: {e}",
                     exc_info=True,
                 )
             except AttributeError as e:


### PR DESCRIPTION
## 目的

- 必要なデータのみ指定して取得する`Resources`パラメータがpipパッケージ(`python-amazon-paapi`)では使用できなかったため、公式SDKに移行する
- レート制限対策としてリクエストごとに1秒間隔をあけるように変更

## やったこと

- `requierments.txt`から`python-amazon-paapi`を削除
- `Dockerfile`に公式SDKをインストールするコマンドを追加
- PA-APIを叩く処理の例外処理の`finally`句に`time.sleep(1)`を入れて、商品情報の取得に失敗した場合は次のリクエストまで1秒開けるようにした
- `.env`ファイルに`HOST`と`REGION`を追記