### PR TITLE
プライム対象商品のみを取得するように変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+paapi5_python_sdk
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/src/infrastructure/service/product_service.py
+++ b/src/infrastructure/service/product_service.py
@@ -76,6 +76,7 @@ class ProductService:
                         partner_tag=os.environ["ASSOCIATE_ID"],
                         partner_type=PartnerType.ASSOCIATES,
                         browse_node_id=self.BROWSE_NODE_LIST[target_browse_node_index],
+                        delivery_flags=["Prime"],
                         item_page=target_page,
                         item_count=10,
                         min_saving_percent=1,


### PR DESCRIPTION
## 目的

 魅力的ではない微妙な商品を除外するため、プライム対象商品のみを取得対象とする

## やったこと

- 商品検索(`search_items()`)で配達フラグ(`delivery_flags`)を"Prime"に設定