### PR TITLE
Docker Composeを再導入

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  app:
+    restart: always
+    build: .
+    container_name: 'camp-gear-sale'
+    tty: true
+    volumes:
+      - .:/workspace/


### PR DESCRIPTION
## 目的

ECSで実行できないことを理由にDockerfile単体での管理に切り替えたが、起動コマンドなど面倒が増えたためDocker Composeで開発作業を快適にする

## やったこと

-  `docker-compose.yml`を作成
- **`Dockerfile`内に**環境変数(`PYTHONPATH`)を設定(今回の変更内容では無いが、前回上手くいかなかったときとの差分)
  ※`docker-compose.yml`に定義する`environment`はDockerイメージには含まれないため