### PR TITLE
【不具合修正】プルリクをdevelopブランチにマージしてもイメージがプッシュされない

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,14 +19,15 @@ phases:
       - docker compose run app python -m unittest discover -v -s ./src/tests/domain -p "test_*.py"
       - |
         if [ "$CODEBUILD_WEBHOOK_EVENT" = "PULL_REQUEST_MERGED" ]; then
-          if [ "$CODEBUILD_WEBHOOK_BASE_REF" = "^refs/heads/develop$" ]; then
+          aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin $ECR_REPOSITORY_URL
+          if [ "$CODEBUILD_WEBHOOK_BASE_REF" = "refs/heads/develop" ]; then
             echo "Pushing the Docker image to the develop repository..."
-            docker tag camp-gear-sale:latest $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/camp-gear-sale-dev:latest
-            docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/camp-gear-sale-dev:latest
-          elif [ "$CODEBUILD_WEBHOOK_BASE_REF" = "^refs/heads/main$" ]; then
+            docker tag camp-gear-sale-app:latest $ECR_REPOSITORY_URL:dev-latest
+            docker push $ECR_REPOSITORY_URL:dev-latest
+          elif [ "$CODEBUILD_WEBHOOK_BASE_REF" = "refs/heads/main" ]; then
             echo "Pushing the Docker image to the production repository..."
-            docker tag camp-gear-sale:latest $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/camp-gear-sale-prd:latest
-            docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/camp-gear-sale-prd:latest
+            docker tag camp-gear-sale-app:latest $ECR_REPOSITORY_URL:prd-latest
+            docker push $ECR_REPOSITORY_URL:prd-latest
           else
             echo "Skipping Docker image push for non-develop and non-main branches"
           fi


### PR DESCRIPTION
## 目的

developブランチにプルリクをマージしてもイメージがプッシュされない不具合の修正

## やったこと

- `docker tag`の対象イメージ名を正しいもの(`camp-gear-sale-app`)に修正
- ECRリポジトリのURLが間違っていたため正しいものを設定（`ECR_REPOSITORY_URL`はSecretsManagerで管理）
- ECRの認証処理を追加