### PR TITLE
Threadsのポストに専用のトラッキングIDを割り当て

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,17 @@ Amazonからセール中の商品を取得し、その商品情報をまとめ�
     # PA-API認証情報
     ACCESS_KEY = {{PA-APIのアクセスキー}}
     SECRET_KEY = {{PA-APIのシークレットキー}}
-    ASSOCIATE_ID = {{AmazonアソシエイトのアソシエイトIDもしくはトラッキングID}}
+    X_ASSOCIATE_ID = {{AmazonアソシエイトのX用のトラッキングID}}
+    THREADS_ASSOCIATE_ID = {{AmazonアソシエイトのThreads用のトラッキングID}}
     HOST = 'webservices.amazon.co.jp'
     REGION = 'us-west-2'
-    
+
     # X API認証情報
     CONSUMER_KEY = {{X APIのコンシューマーキー}}
     CONSUMER_SECRET = {{X APIのコンシューマーシークレット}}
     ACCESS_TOKEN = {{X APIのアクセストークン}}
     ACCESS_TOKEN_SECRET = {{X APIのアクセストークンシークレット}}
-    
+
     # ThreadsAPI認証情報
     THREADS_ACCESS_TOKEN = {{ThreadsAPIのアクセストークン}}
     ```

--- a/src/application/usecase/post_camp_gear_sale_use_case.py
+++ b/src/application/usecase/post_camp_gear_sale_use_case.py
@@ -28,6 +28,9 @@ class PostCampGearSaleUseCase:
 
         product.title = product.title.replace("##", "#")
 
+        shortener = Shortener()
+        product.short_url = shortener.tinyurl.short(product.full_url)
+
         excess_length = post.calculate_excess_length(
             [
                 product.title,
@@ -38,9 +41,6 @@ class PostCampGearSaleUseCase:
         )
         if excess_length > 0:
             product.title = post.shorten_content(product.title, excess_length)
-
-        shortener = Shortener()
-        product.short_url = shortener.tinyurl.short(product.full_url)
 
         post_content = post.create_content(
             [

--- a/src/application/usecase/post_camp_gear_sale_use_case.py
+++ b/src/application/usecase/post_camp_gear_sale_use_case.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 from pyshorteners import Shortener
@@ -12,43 +13,54 @@ class PostCampGearSaleUseCase:
         self.post_service = post_service
 
     def handle(self):
-        product = self.product_repository.fetch_sale_product()
-
-        brand_notation_list = [
-            bn for bn in re.split(r"\((.*?)\)", product.brand) if bn != ""
-        ]
-        brand_notation_list += [
-            bn.replace(" ", "") for bn in brand_notation_list if " " in bn
-        ]
 
         post = Post()
-
-        for bn in brand_notation_list:
-            product.title = post.add_hashtags(product.title, bn)
-
-        product.title = product.title.replace("##", "#")
-
         shortener = Shortener()
-        product.short_url = shortener.tinyurl.short(product.full_url)
 
-        excess_length = post.calculate_excess_length(
-            [
-                product.title,
-                str(product.discount_rate),
-                str(product.discount_amount),
-                product.short_url,
+        associate_ids = {
+            "x": os.environ["X_ASSOCIATE_ID"],
+            "threads": os.environ["THREADS_ASSOCIATE_ID"],
+        }
+
+        for key, associate_id in associate_ids.items():
+            product = self.product_repository.fetch_sale_product(associate_id)
+
+            brand_notation_list = [
+                bn for bn in re.split(r"\((.*?)\)", product.brand) if bn != ""
             ]
-        )
-        if excess_length > 0:
-            product.title = post.shorten_content(product.title, excess_length)
-
-        post_content = post.create_content(
-            [
-                product.discount_rate,
-                product.discount_amount,
-                product.title,
-                product.short_url,
+            brand_notation_list += [
+                bn.replace(" ", "") for bn in brand_notation_list if " " in bn
             ]
-        )
 
-        self.post_service.post(post_content, product.image)
+            for bn in brand_notation_list:
+                product.title = post.add_hashtags(product.title, bn)
+            product.title = product.title.replace("##", "#")
+
+            product.short_url = shortener.tinyurl.short(product.full_url)
+
+            excess_length = post.calculate_excess_length(
+                [
+                    product.title,
+                    str(product.discount_rate),
+                    str(product.discount_amount),
+                    product.short_url,
+                ]
+            )
+            if excess_length > 0:
+                product.title = post.shorten_content(product.title, excess_length)
+
+            post_content = post.create_content(
+                [
+                    product.discount_rate,
+                    product.discount_amount,
+                    product.title,
+                    product.short_url,
+                ]
+            )
+
+            if key == "x":
+                self.post_service.post_to_x(post_content, product.image)
+            elif key == "threads":
+                self.post_service.post_to_threads(post_content)
+            else:
+                continue

--- a/src/infrastructure/repository/product_repository.py
+++ b/src/infrastructure/repository/product_repository.py
@@ -3,5 +3,5 @@ class ProductRepository:
     def __init__(self, product_service):
         self.product_service = product_service
 
-    def fetch_sale_product(self):
-        return self.product_service.fetch_sale_product()
+    def fetch_sale_product(self, associate_id):
+        return self.product_service.fetch_sale_product(associate_id)

--- a/src/infrastructure/service/post_service.py
+++ b/src/infrastructure/service/post_service.py
@@ -25,7 +25,7 @@ class PostService:
             media_upload_endpoint, auth=auth, files={"media": image}
         ).json()["media_id_string"]
 
-    def post(self, content, image):
+    def post_to_x(self, content, image):
 
         post = Post()
 
@@ -33,15 +33,37 @@ class PostService:
         media_id = self.fetch_media_id(auth, self.MEDIA_UPLOAD_ENDPOINT, image)
         x_post_payload = post.create_x_post_payload(content, media_id)
 
-        threads_auth = "Bearer " + os.environ["THREADS_ACCESS_TOKEN"]
-        threads_post_payload = post.create_threads_post_payload(content)
-
         try:
             x_response = requests.post(
                 self.POST_TWEET_ENDPOINT, auth=auth, json=x_post_payload
             )
             logger.info("【X API】メディアコンテナ作成リクエストのレスポンス : %s", x_response.json())
 
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 429:
+                logger.error(
+                    f"レート上限に達しました。: {e}",
+                    exc_info=True,
+                )
+        except requests.exceptions.RequestException as e:
+            logger.error(
+                f"リクエスト中にエラーが発生しました。: {e}",
+                exc_info=True,
+            )
+        except Exception as e:
+            logger.error(
+                f"投稿中に予期せぬエラーが発生しました。: {e}",
+                exc_info=True,
+            )
+
+    def post_to_threads(self, content):
+
+        post = Post()
+
+        threads_auth = "Bearer " + os.environ["THREADS_ACCESS_TOKEN"]
+        threads_post_payload = post.create_threads_post_payload(content)
+
+        try:
             threads_response = requests.post(
                 "https://graph.threads.net/v1.0/me/threads",
                 json=threads_post_payload,

--- a/src/infrastructure/service/product_service.py
+++ b/src/infrastructure/service/product_service.py
@@ -62,7 +62,7 @@ class ProductService:
             region=os.environ["REGION"],
         )
 
-    def fetch_sale_product(self):
+    def fetch_sale_product(self, associate_id):
         amazon_api = self.auth_amazon_api()
 
         is_found = False
@@ -73,7 +73,7 @@ class ProductService:
             try:
                 sale_product_list = amazon_api.search_items(
                     SearchItemsRequest(
-                        partner_tag=os.environ["ASSOCIATE_ID"],
+                        partner_tag=associate_id,
                         partner_type=PartnerType.ASSOCIATES,
                         browse_node_id=self.BROWSE_NODE_LIST[target_browse_node_index],
                         delivery_flags=["Prime"],


### PR DESCRIPTION
## 目的

下記2点の対応。

- Amazonアソシエイトの収益をXとThreads別々で集計できるようにする。
- 文字数上限チェックが正常に機能してない不具合の修正。

## やったこと

- 文字数上限のチェック後に短縮URLを生成していたため、短縮URLの生成処理を前に移動。
- トラッキングID（アソシエイトID）の環境変数`ASSOCIATE_ID`をX用とThreads用それぞれで用意。
  | ポスト先 | トラッキングIDの環境変数 |
  | - | - |
  | X | `X_ASSOCIATE_ID` | 
  | Threads | `THREADS_ASSOCIATE_ID` |
- 上記に伴いREADMEの環境変数の項目も修正
- 商品取得処理(`fetch_sale_product()`)をトラッキングIDごとに別々に取得できるようにするため、引数に`associate_id`を追加
- ポスト処理(`post()`)をX用(`post_to_x()`)とThreads用(`post_to_threads`)に分割